### PR TITLE
fix streamlit imports

### DIFF
--- a/src/telemetry/telemetry_dashboard.py
+++ b/src/telemetry/telemetry_dashboard.py
@@ -1,14 +1,16 @@
 from pathlib import Path
 from typing import List
+import sys
 
 import streamlit as st
 import pandas as pd
 
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT.parent) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT.parent))
+
 from telemetry_loader import TelemetryLoader
 from src.lap.lap_telemetry import LapTelemetry
-
-
-PROJECT_ROOT = Path(__file__).resolve().parent
 
 
 def _get_tracks() -> List[str]:


### PR DESCRIPTION
## Summary
- ensure Streamlit dashboard works with absolute imports by adding project root to `sys.path`
- correct `PROJECT_ROOT` to point to `src` directory

## Testing
- `python -m py_compile src/telemetry/telemetry_dashboard.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5c90c23dc832cae58fe1fa196512e